### PR TITLE
Ensure compatibility with Auto Mod Config with load after

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -16,5 +16,6 @@
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>
+		<li>garethp.modlistconfigurator</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
So the mod itself can be configured in modpack configurations, making sure loading settings are set properly.